### PR TITLE
Another color tweak for vs2017 dark theme.

### DIFF
--- a/Custom Syntax Styles/Monokai.xml
+++ b/Custom Syntax Styles/Monokai.xml
@@ -181,7 +181,6 @@
 			</KeyWords>
 			<KeyWords name="Literals" bold="true" italic="false" color="#DD2867">
 				<Key word="null" />
-				<Key word="value" />
 			</KeyWords>
 			<KeyWords name="DebuggerPrefixes" bold="false" italic="true" color="DarkOrange">
 				<Key word="BPDBreakpoint" />

--- a/Custom Syntax Styles/SourcePawn_Syntax.xml
+++ b/Custom Syntax Styles/SourcePawn_Syntax.xml
@@ -181,7 +181,6 @@
 			</KeyWords>
 			<KeyWords name="Literals" bold="true" italic="false" color="Black">
 				<Key word="null" />
-				<Key word="value" />
 			</KeyWords>
 			<KeyWords name="DebuggerPrefixes" bold="false" italic="true" color="DarkOrange">
 				<Key word="BPDBreakpoint" />

--- a/Custom Syntax Styles/VisualStudio2017_Dark.xml
+++ b/Custom Syntax Styles/VisualStudio2017_Dark.xml
@@ -179,9 +179,8 @@
 				<Key word="add" />
 				<Key word="remove" />
 			</KeyWords>
-			<KeyWords name="Literals" bold="true" italic="false" color="#dcdcdc">
+			<KeyWords name="Literals" bold="true" italic="false" color="#569cd6">
 				<Key word="null" />
-				<Key word="value" />
 			</KeyWords>
 			<KeyWords name="DebuggerPrefixes" bold="false" italic="true" color="DarkOrange">
 				<Key word="BPDBreakpoint" />


### PR DESCRIPTION
Changed color of ``null`` to match color of ``nullptr`` in vs:
SP:
![image](https://user-images.githubusercontent.com/31375974/52105307-48379080-25ff-11e9-9256-31b17dd11b1d.png)
VS:
![image](https://user-images.githubusercontent.com/31375974/52105312-54235280-25ff-11e9-8652-a25bce61b828.png)

Also removed ``value`` keyword from ``Literals`` section, as it seems to not used in sp at all, please correct me if I'm wrong. I would've let it be there but it colors it even when it's just a variable name, which seems kinda off to me:
![image](https://user-images.githubusercontent.com/31375974/52105425-c300ab80-25ff-11e9-82f9-c21a62fe1aeb.png)

